### PR TITLE
Fix logo fade transition on start

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,8 +209,10 @@
       }
       // Tampilkan iframe, sembunyikan logo
       iframe.style.display = 'block';
-      logo.style.display = 'none';
       logo.style.opacity = '0';
+      logo.addEventListener('transitionend', () => {
+        logo.style.display = 'none';
+      }, { once: true });
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- fix the logo fade-out animation so the image fades before being hidden

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684150e2310483218b72c5bc8e2493a5